### PR TITLE
PR to update CIP-0091 (as agreed with Bernhard)

### DIFF
--- a/cip-0091/cip-0091.md
+++ b/cip-0091/cip-0091.md
@@ -47,15 +47,15 @@ The proposed framework allocates a total potential weight of 10 across two key a
 | Deliverable | Acceptance Criteria | Deadline | Weight Earned |
 |--------------|--------------------|-----------|----------------|
 | MVP | • Demonstrate transaction processing between Canton and Zenith EVM (prev. called VB) <br> • Implement verify() function in Daml <br> • Deploy Zenith EVM testnet on a Canton Test Network (local multi-node environment) <br> • Submit feature-complete pull requests to the relevant upstream repositories, and receive preliminary approval from maintainers | +4 months from CIP Approval | +1 |
-| Demonstrated composability on Mainnet | • Deploy VB on Canton Mainnet, interacting with Zenith Mainnet <br> • Deploy an asset on a VB and compose with a Daml-native stablecoin through an existing Daml-native DEX (as agreed with the Accountability Committee) into an atomic swap | +4 Months from MVP | +3 |
+| Demonstrated composability based on Canton main branch | • Deploy Zenith EVM (prev. VB) on a local multi-node Canton test network built from the Canton and Splice main branches demonstrating that all needed changes have been accepted by the core developers and will be released with the next MainNet upgrade <br> • Deploy an asset on Zenith EVM and compose with a Daml-native asset through a Daml-native DEX deployed on the Canton test network into an atomic swap | +4 Months from MVP | +3 |
 
 ### Growth and Adoption Weight — Predicated upon demonstration of Daml to VB composability:
 
 | Deliverable | Acceptance Criteria | Deadline | Weight Earned |
 |--------------|--------------------|-----------|----------------|
-| Enterprise Production Deployments | Any enterprise or institution approved by the Canton Foundation that deploys > $10M of TVL on Canton via VBs. | Within 12 months of Mainnet delivery | +0.5 per approved party up to a max of +1.5 |
-| Canton Coin Burn Contribution | All CC Burn attributed to VBs. | Within 12 months of Mainnet delivery | +0.5 per 10M of $CC burn up to a max of +3 |
-| Real-world assets (RWAs) issued | Over $1 billion in RWAs issued on Canton Virtual Blockchains. | Within 12 months of Mainnet delivery | +1.5 |
+| Enterprise Production Deployments | Any enterprise or institution approved by the Canton Foundation that deploys > $10M of TVL on Canton via VBs. | Within 12 months of the MainNet upgrade including external_call() | +0.5 per approved party up to a max of +1.5 |
+| Canton Coin Burn Contribution | All CC Burn attributed to VBs. | Within 12 months of the MainNet upgrade including external_call() | +0.5 per 10M of $CC burn up to a max of +3 |
+| Real-world assets (RWAs) issued | Over $1 billion in RWAs issued on Canton Virtual Blockchains. | Within 12 months of the MainNet upgrade including external_call() | +1.5 |
 
 ## Rationale:
 

--- a/cip-0091/cip-0091.md
+++ b/cip-0091/cip-0091.md
@@ -89,5 +89,6 @@ This CIP is licensed under CC0-1.0: [Creative Commons CC0 1.0 Universal](https:/
 * **2025-10-28:** Re-write of the proposal.
 * **2025-11-04:** Approved CIP.
 * **2026-03-11:** [Text updated after request](https://lists.sync.global/g/supervalidator-announce/topic/cip_0074_bitgo_interpretation/117962023)
+* **2026-06-10:** Approved languge merged into CIP
 
 


### PR DESCRIPTION
This PR serves the purpose to accommodate the change in demonstrating our milestone 2, as proposed by and agreed on with Bernhard. Our demonstration deadline is fast approaching, and therefore we request the Tokenomics committee to review and vote on this change to unblock our ability to demonstrate Milestone 2\.

I'd like to reiterate that this change **does not extend our Milestone 2 delivery time for full MainNet readiness.** We still need to complete the demonstration of what will work on MainNet within 4 months of Milestone 1 delivery (27 Feb 2026\) as per the original CIP deadlines. It is only the rollout of the functionality that take place with Canton 3.6 (the release following Canton 3.5).

I am sharing all the context below:

In the third week of March, we have been informed by Bernhard that DA's engineering team was under heavy load due to the coming code freeze (middle of April) for the Canton 3.5 release, and thus would not be able to complete the review of the `external_call` PRs on time to get the `external_call` primitive into the Canton 3.5 release. This impacts Zenith's ability to demonstrate the [next milestone of CIP-0091](https://github.com/canton-foundation/cips/blob/main/cip-0091/cip-0091.md#deliverables-for-full-sv-reward) within 4 months of Milestone 1 delivery (27 Feb 2026\) because Milestone 2 requires the rollout of the `external_call` to Canton's MainNet.

**Bernhard therefore proposed an alternative way for us to demonstrate our Milestone 2 within the same deadline,** however this requires a change in the CIP. We are attaching his proposal and confirmation in writing.

As per Bernhard's proposal (attached): "**Digital Asset would therefore support an adjustment to Zenith's milestone 2** allowing for a demonstration of the capabilities not on MainNet, but on components built entirely from the `main` branches of Canton and Splice, thus demonstrating what will work on MainNet with the next protocol version upgrade (likely Splice 0.7/Canton 3.6/PV36)." (For the demo, the `main` branch will have to include `external_call` already, fully merged.)

This PR reflects the above changes.

<img width="1551" height="269" alt="Written summary from Bernhard" src="https://github.com/user-attachments/assets/86e05608-7c88-4e7b-8526-0900a1d16644" />



We have **discussed it in detail with the Accountability committee, and received their approval on 31 March 2026,** given we have an explicit dependency here on DA's engineering team, and this is not a "took longer than anticipated" scenario or an external third-party dependency. Ryan from the Acc committee **presented this to Tokenomics on 1 April**, and since **some committee members asked for some more time to review the change**, it **was agreed to have an async discussion and vote about it**.

We'd be happy to answer any questions that may arise.

\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_\_

In addition, I'd also like to share details regarding some questions we received on any overlap between Zenith's CIP and dev fund grant. This topic has been discussed with Shaul and tech-ops voting group members extensively, and **the grant terms have changed prior to the vote to address all earlier concerns raised, through:**

1. **decreasing the grant amount,**  
2. **making the grant non-perpetual,**  
3. **adding a clear cessation clause to the grant,**  
4. **locking 100% of SV rewards.**  

These are reflected in the grant as follows:

* **Grant Cessation Clause: If Zenith successfully closes its Series A** (with confirmation of capital call), **this grant will immediately cease.** Zenith will notify the Committee promptly upon closing.  
* **SV reward alignment:**  
  * For the duration of the Ecosystem Grant:  
    * Prior to mainnet launch: **100% of Zenith's SV rewards will be locked.** (Already visible in [CCView](https://ccview.io/sv-locking/).)  
    * Upon mainnet release: All liquid rewards to date, the 30% unrestricted allocation of lifetime SV rewards, will be used exclusively for liquidity bootstrapping in Canton Foundation-approved pools with remaining 70% continuing to be locked.  
* **Review and off-ramps:** Quarterly evaluation by the Tech & Ops Committee (or Core Contributor Group) based on the proposed quarterly reporting framework including published release notes, repository activity, SLO achievement (critical vulnerabilities mitigated within 48 hours, external PRs reviewed within 5 business days), and ecosystem deliverables.**The Committee may suspend or terminate future payments after any quarter if performance falls short.**

The above clauses ensure that Zenith can continue building EVM compatibility for Canton but clearly defines the cessation parameters of the grant.
