### PR TITLE
Add FA weights to CIP-0104 spec

### DIFF
--- a/cip-0104/cip-0104.md
+++ b/cip-0104/cip-0104.md
@@ -73,6 +73,7 @@ Use the view hashes visible to the sequencer on the confirmation request to dete
    ```
 
    using integer arithmetic, and attribute `per_app_traffic_weight` to every app confirmer of the envelope.
+6. For every featured app involved, multiply the `per_app_traffic_weight` by the `activity_weight` set on the `FeaturedAppRight`.
 
 Note that the computation in Item 5 takes care of distributing the traffic cost not attributed to app envelopes in a weighted fashion among the app envelopes.
 When all envelopes have an app confirmer, it becomes `per_app_traffic_weight = envelope_traffic_cost / num_app_confirmers`, as expected.
@@ -153,6 +154,17 @@ Note that the CIP proposes introducing extra endpoints instead of extending the 
 
 1. Traffic summaries can be read by clients as soon as the corresponding message has been sequenced, and not only once the confirmation request has been completed, which may be up to 30s later.
 2. The `/v2/events` stream is not held up by a potentially delayed app activity record computation.
+
+#### Featured App Weights
+
+The CIP proposes to add the ability to adjust the app rewards that a featured app receives by setting a weight on the `FeaturedAppRight` contract. The weight is applied in the [activity record computation](#activity-record-computation-details).
+Concretely:
+
+1. Add a field `activity_weight` to `FeaturedAppRight`.
+2. Adjust the `DsoRules_GrantFeaturedAppRight` and `DsoRules_RevokeFeaturedAppRight` governance choices to optionally take `activity_weight`, with the default being `1.0`.
+3. Add a new `DsoRules_UpdateFeaturedAppRight` governance choice to adjust the `activity_weight`.
+4. Make the adjustments to the SV UIs and backing APIs to allow SV governance to adjust the `activity_weight` on `FeaturedAppRight`
+
 
 ### Free Protocol-Conformant Confirmation Responses
 

--- a/cip-0104/cip-0104.md
+++ b/cip-0104/cip-0104.md
@@ -73,7 +73,7 @@ Use the view hashes visible to the sequencer on the confirmation request to dete
    ```
 
    using integer arithmetic, and attribute `per_app_traffic_weight` to every app confirmer of the envelope.
-6. For every featured app involved, multiply the `per_app_traffic_weight` by the `activity_weight` set on the `FeaturedAppRight`.
+6. For every featured app involved, multiply the `per_app_traffic_weight` by the `activityWeight` set on the `FeaturedAppRight`.
 
 Note that the computation in Item 5 takes care of distributing the traffic cost not attributed to app envelopes in a weighted fashion among the app envelopes.
 When all envelopes have an app confirmer, it becomes `per_app_traffic_weight = envelope_traffic_cost / num_app_confirmers`, as expected.
@@ -160,10 +160,10 @@ Note that the CIP proposes introducing extra endpoints instead of extending the 
 The CIP proposes to add the ability to adjust the app rewards that a featured app receives by setting a weight on the `FeaturedAppRight` contract. The weight is applied in the [activity record computation](#activity-record-computation-details).
 Concretely:
 
-1. Add a field `activity_weight` to `FeaturedAppRight`.
-2. Adjust the `DsoRules_GrantFeaturedAppRight` and `DsoRules_RevokeFeaturedAppRight` governance choices to optionally take `activity_weight`, with the default being `1.0`.
-3. Add a new `DsoRules_UpdateFeaturedAppRight` governance choice to adjust the `activity_weight`.
-4. Make the adjustments to the SV UIs and backing APIs to allow SV governance to adjust the `activity_weight` on `FeaturedAppRight`
+1. Add a field `activityWeight` to `FeaturedAppRight`.
+2. Adjust the `DsoRules_GrantFeaturedAppRight` governance choice to optionally take `activityWeight`, with the default being `1.0`.
+3. Add a new `DsoRules_UpdateFeaturedAppRight` governance choice to adjust the `activityWeight`.
+4. Adjust the SV UIs and backing APIs to allow SV governance to change the `activityWeight` on `FeaturedAppRight`
 
 
 ### Free Protocol-Conformant Confirmation Responses

--- a/cip-0104/cip-0104.md
+++ b/cip-0104/cip-0104.md
@@ -434,6 +434,7 @@ TODO: build and reference here
 This CIP is licensed under CC0-1.0: [Creative Commons CC0 1.0 Universal](https://creativecommons.org/publicdomain/zero/1.0/)
 
 ## Changelog
+- 2025-06-30: Propose amendment for featured app weights.
 - 2026-02-12: CIP Approved.
 - 2026-01-29: draft published
 - 2026-01-10: change to share app rewards among confirmers instead of informees

--- a/cip-0104/cip-0104.md
+++ b/cip-0104/cip-0104.md
@@ -79,7 +79,7 @@ Note that the computation in Item 5 takes care of distributing the traffic cost 
 When all envelopes have an app confirmer, it becomes `per_app_traffic_weight = envelope_traffic_cost / num_app_confirmers`, as expected.
 See the [Example: Views and Envelopes for DvP settlement](#example-views-and-envelopes-for-dvp-settlement) section for concrete calculation examples.
 
-The computations are performed using integer arithmetic for efficiency and determinism reasons.
+The computations in steps 1-5 are performed using integer arithmetic for efficiency and determinism reasons.
 For confirmation requests whose traffic size is below 100 MB, they can be performed with 64-bit signed integers without risk of overflow.
 
 

--- a/cip-0104/cip-0104.md
+++ b/cip-0104/cip-0104.md
@@ -81,6 +81,7 @@ See the [Example: Views and Envelopes for DvP settlement](#example-views-and-env
 
 The computations in steps 1-5 are performed using integer arithmetic for efficiency and determinism reasons.
 For confirmation requests whose traffic size is below 100 MB, they can be performed with 64-bit signed integers without risk of overflow.
+The computation in Step 6 is performed using Daml's `Decimal` arithmetic as `floor (intToDecimal per_app_traffic_weight * activityWeight)`.
 
 
 #### Adjust App Reward Accounting

--- a/cip-0104/cip-0104.md
+++ b/cip-0104/cip-0104.md
@@ -415,6 +415,21 @@ Thus the totals are as follows:
 * Bank1: 4 kB
 * Bank2: 7 kB
 
+#### Calculation Example 4: Alice, Bank1, and Bank2 are app providers with Alice of weight 0.5
+
+The summed up `per_app_traffic_weight`s are as per Example 3:
+
+* Alice: 14 kB
+* Bank1: 4 kB
+* Bank2: 7 kB
+
+The weight is applied to get the final activity records:
+
+* Alice: 7 kB
+* Bank1: 4 kB
+* Bank2: 7 kB
+
+
 #### Observing and Optimizing View Decompositions
 
 Note that the actual view decomposition of an app very much depends on their Daml models, and is best observed in production.


### PR DESCRIPTION
The app marker mechanism at the moment allows governance bodies to respond to observed behaviours and imbalances by amending marker guidance, observing through public explorers, and enforcement.
We propose to add a "featured app weights" to CIP-0104 that would allow similarly fine-grained adjustments to app rewards on a per-app basis.